### PR TITLE
Implement GUI configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,8 @@ dependencies = [
  "gtk4",
  "hyprparser",
  "libc",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -409,6 +411,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
@@ -510,6 +518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +547,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ edition = "2021"
 gtk = { version = "0.9.2", package = "gtk4" }
 hyprparser = { git = "https://github.com/nnyyxxxx/hyprparser.git" }
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -94,6 +94,28 @@ impl ConfigGUI {
         let gear_button = Button::from_icon_name("emblem-system-symbolic");
         header_bar.pack_start(&gear_button);
 
+        let tooltip_button = Button::new();
+        let question_mark_icon = Image::from_icon_name("dialog-question-symbolic");
+        tooltip_button.set_child(Some(&question_mark_icon));
+        tooltip_button.set_has_frame(false);
+        header_bar.pack_start(&tooltip_button);
+
+        let popover = Popover::new();
+        let tooltip_text = "The save button saves the options that you chose in the gui and exports it to json format, likewise the load button loads these saved options from the exported json file; automatically filling in the options in the gui with the specified ones in the json file, clicking save to apply these changes is still necessary though.";
+        let tooltip_label = Label::new(Some(tooltip_text));
+        tooltip_label.set_margin_top(5);
+        tooltip_label.set_margin_bottom(5);
+        tooltip_label.set_margin_start(5);
+        tooltip_label.set_margin_end(5);
+        tooltip_label.set_wrap(true);
+        tooltip_label.set_max_width_chars(50);
+        popover.set_child(Some(&tooltip_label));
+
+        tooltip_button.connect_clicked(move |button| {
+            popover.set_parent(button);
+            popover.popup();
+        });
+
         let save_button = Button::with_label("Save");
         header_bar.pack_end(&save_button);
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -74,7 +74,6 @@ pub struct ConfigGUI {
     changed_options: Rc<RefCell<HashMap<(String, String), String>>>,
     stack: Stack,
     sidebar: StackSidebar,
-    gear_button: Button,
     load_config_button: Button,
     save_config_button: Button,
 }
@@ -144,7 +143,6 @@ impl ConfigGUI {
             changed_options: Rc::new(RefCell::new(HashMap::new())),
             stack,
             sidebar,
-            gear_button,
             load_config_button,
             save_config_button,
         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,3 +1,4 @@
+use gtk::glib::{clone, MainContext};
 use gtk::{
     gdk, prelude::*, Application, ApplicationWindow, Box, Button, ColorButton, DropDown, Entry,
     Frame, HeaderBar, Image, Label, MessageDialog, Orientation, Popover, ScrolledWindow,
@@ -7,6 +8,8 @@ use gtk::{
 use hyprparser::HyprlandConfig;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 fn add_dropdown_option(
@@ -72,6 +75,9 @@ pub struct ConfigGUI {
     changed_options: Rc<RefCell<HashMap<(String, String), String>>>,
     stack: Stack,
     sidebar: StackSidebar,
+    gear_button: Button,
+    load_config_button: Button,
+    save_config_button: Button,
 }
 
 impl ConfigGUI {
@@ -86,6 +92,9 @@ impl ConfigGUI {
             .show_title_buttons(false)
             .title_widget(&gtk::Label::new(Some("Hyprland Configuration")))
             .build();
+
+        let gear_button = Button::from_icon_name("emblem-system-symbolic");
+        header_bar.pack_start(&gear_button);
 
         let save_button = Button::with_label("Save");
         header_bar.pack_end(&save_button);
@@ -107,6 +116,27 @@ impl ConfigGUI {
         sidebar.set_stack(&stack);
         sidebar.set_width_request(200);
 
+        let popover = Popover::new();
+        popover.set_parent(&gear_button);
+
+        let popover_box = Box::new(Orientation::Vertical, 5);
+        popover_box.set_margin_top(5);
+        popover_box.set_margin_bottom(5);
+        popover_box.set_margin_start(5);
+        popover_box.set_margin_end(5);
+
+        let load_config_button = Button::with_label("Load HyprGUI Config");
+        let save_config_button = Button::with_label("Save HyprGUI Config");
+
+        popover_box.append(&load_config_button);
+        popover_box.append(&save_config_button);
+
+        popover.set_child(Some(&popover_box));
+
+        gear_button.connect_clicked(move |_| {
+            popover.popup();
+        });
+
         ConfigGUI {
             window,
             config_widgets,
@@ -115,6 +145,151 @@ impl ConfigGUI {
             changed_options: Rc::new(RefCell::new(HashMap::new())),
             stack,
             sidebar,
+            gear_button,
+            load_config_button,
+            save_config_button,
+        }
+    }
+
+    pub fn setup_config_buttons(gui: Rc<RefCell<ConfigGUI>>) {
+        let gui_clone = gui.clone();
+        gui.borrow().load_config_button.connect_clicked(move |_| {
+            let gui = gui_clone.clone();
+            MainContext::default().spawn_local(clone!(@strong gui => async move {
+                let file_chooser = gtk::FileChooserDialog::new(
+                    Some("Load HyprGUI Config"),
+                    Some(&gui.borrow().window),
+                    gtk::FileChooserAction::Open,
+                    &[("Cancel", gtk::ResponseType::Cancel), ("Open", gtk::ResponseType::Accept)]
+                );
+
+                if file_chooser.run_future().await == gtk::ResponseType::Accept {
+                    if let Some(file) = file_chooser.file() {
+                        if let Some(path) = file.path() {
+                            gui.borrow_mut().load_hyprgui_config(&path);
+                        }
+                    }
+                }
+                file_chooser.close();
+            }));
+        });
+
+        let gui_clone = gui.clone();
+        gui.borrow().save_config_button.connect_clicked(move |_| {
+            let gui = gui_clone.clone();
+            MainContext::default().spawn_local(clone!(@strong gui => async move {
+                let file_chooser = gtk::FileChooserDialog::new(
+                    Some("Save HyprGUI Config"),
+                    Some(&gui.borrow().window),
+                    gtk::FileChooserAction::Save,
+                    &[("Cancel", gtk::ResponseType::Cancel), ("Save", gtk::ResponseType::Accept)]
+                );
+
+                file_chooser.set_current_name("hyprgui_config.json");
+
+                if file_chooser.run_future().await == gtk::ResponseType::Accept {
+                    if let Some(file) = file_chooser.file() {
+                        if let Some(path) = file.path() {
+                            gui.borrow_mut().save_hyprgui_config(&path);
+                        }
+                    }
+                }
+                file_chooser.close();
+            }));
+        });
+    }
+
+    fn load_hyprgui_config(&mut self, path: &PathBuf) {
+        match fs::read_to_string(path) {
+            Ok(content) => {
+                if let Ok(config) = serde_json::from_str::<HashMap<String, String>>(&content) {
+                    for (key, value) in config {
+                        let parts: Vec<&str> = key.split(':').collect();
+                        if parts.len() == 2 {
+                            let category = parts[0].to_string();
+                            let name = parts[1].to_string();
+                            if let Some(widget) = self.config_widgets.get(&category) {
+                                if let Some(option_widget) = widget.options.get(&name) {
+                                    self.set_widget_value(option_widget, &value);
+                                    self.changed_options
+                                        .borrow_mut()
+                                        .insert((category, name), value);
+                                }
+                            }
+                        }
+                    }
+                    self.custom_info_popup("Config Loaded", "HyprGUI configuration loaded successfully.", false);
+                } else {
+                    self.custom_error_popup("Invalid Config", "Failed to parse the configuration file.", false);
+                }
+            }
+            Err(e) => {
+                self.custom_error_popup(
+                    "Loading Failed",
+                    &format!("Failed to read the configuration file: {}", e),
+                    false,
+                );
+            }
+        }
+    }
+
+    fn save_hyprgui_config(&mut self, path: &PathBuf) {
+        let config: HashMap<String, String> = self
+            .changed_options
+            .borrow()
+            .iter()
+            .map(|((category, name), value)| (format!("{}:{}", category, name), value.clone()))
+            .collect();
+
+        match serde_json::to_string_pretty(&config) {
+            Ok(json) => match fs::write(path, json) {
+                Ok(_) => {
+                    self.custom_info_popup("Config Saved", "HyprGUI configuration saved successfully.", false);
+                }
+                Err(e) => {
+                    self.custom_error_popup(
+                        "Saving Failed",
+                        &format!("Failed to write the configuration file: {}", e),
+                        false,
+                    );
+                }
+            },
+            Err(e) => {
+                self.custom_error_popup(
+                    "Serialization Failed",
+                    &format!("Failed to serialize the configuration: {}", e),
+                    false,
+                );
+            }
+        }
+    }
+
+    fn set_widget_value(&self, widget: &Widget, value: &str) {
+        if let Some(spin_button) = widget.downcast_ref::<SpinButton>() {
+            if let Ok(float_value) = value.parse::<f64>() {
+                spin_button.set_value(float_value);
+            }
+        } else if let Some(entry) = widget.downcast_ref::<Entry>() {
+            entry.set_text(value);
+        } else if let Some(switch) = widget.downcast_ref::<Switch>() {
+            switch.set_active(value == "true");
+        } else if let Some(color_button) = widget.downcast_ref::<ColorButton>() {
+            let dummy_config = HyprlandConfig::new();
+            if let Some((red, green, blue, alpha)) = dummy_config.parse_color(value) {
+                color_button.set_rgba(&gdk::RGBA::new(red, green, blue, alpha));
+            }
+        } else if let Some(dropdown) = widget.downcast_ref::<DropDown>() {
+            let model = dropdown.model().unwrap();
+            for i in 0..model.n_items() {
+                if let Some(item) = model.item(i) {
+                    if let Some(string_object) = item.downcast_ref::<gtk::StringObject>() {
+                        if string_object.string() == value {
+                            dropdown.set_selected(i);
+                            break;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,7 +1,6 @@
-use gtk::glib::{clone, MainContext};
 use gtk::{
-    gdk, prelude::*, Application, ApplicationWindow, Box, Button, ColorButton, DropDown, Entry,
-    Frame, HeaderBar, Image, Label, MessageDialog, Orientation, Popover, ScrolledWindow,
+    gdk, glib, prelude::*, Application, ApplicationWindow, Box, Button, ColorButton, DropDown,
+    Entry, Frame, HeaderBar, Image, Label, MessageDialog, Orientation, Popover, ScrolledWindow,
     SpinButton, Stack, StackSidebar, StringList, Switch, Widget,
 };
 
@@ -152,15 +151,18 @@ impl ConfigGUI {
     }
 
     pub fn setup_config_buttons(gui: Rc<RefCell<ConfigGUI>>) {
-        let gui_clone = gui.clone();
+        let gui_clone = Rc::clone(&gui);
         gui.borrow().load_config_button.connect_clicked(move |_| {
-            let gui = gui_clone.clone();
-            MainContext::default().spawn_local(clone!(@strong gui => async move {
+            let gui = Rc::clone(&gui_clone);
+            glib::MainContext::default().spawn_local(async move {
                 let file_chooser = gtk::FileChooserDialog::new(
                     Some("Load HyprGUI Config"),
                     Some(&gui.borrow().window),
                     gtk::FileChooserAction::Open,
-                    &[("Cancel", gtk::ResponseType::Cancel), ("Open", gtk::ResponseType::Accept)]
+                    &[
+                        ("Cancel", gtk::ResponseType::Cancel),
+                        ("Open", gtk::ResponseType::Accept),
+                    ],
                 );
 
                 if file_chooser.run_future().await == gtk::ResponseType::Accept {
@@ -171,18 +173,21 @@ impl ConfigGUI {
                     }
                 }
                 file_chooser.close();
-            }));
+            });
         });
 
-        let gui_clone = gui.clone();
+        let gui_clone = Rc::clone(&gui);
         gui.borrow().save_config_button.connect_clicked(move |_| {
-            let gui = gui_clone.clone();
-            MainContext::default().spawn_local(clone!(@strong gui => async move {
+            let gui = Rc::clone(&gui_clone);
+            glib::MainContext::default().spawn_local(async move {
                 let file_chooser = gtk::FileChooserDialog::new(
                     Some("Save HyprGUI Config"),
                     Some(&gui.borrow().window),
                     gtk::FileChooserAction::Save,
-                    &[("Cancel", gtk::ResponseType::Cancel), ("Save", gtk::ResponseType::Accept)]
+                    &[
+                        ("Cancel", gtk::ResponseType::Cancel),
+                        ("Save", gtk::ResponseType::Accept),
+                    ],
                 );
 
                 file_chooser.set_current_name("hyprgui_config.json");
@@ -195,7 +200,7 @@ impl ConfigGUI {
                     }
                 }
                 file_chooser.close();
-            }));
+            });
         });
     }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -208,9 +208,9 @@ impl ConfigGUI {
                 if let Ok(config) = serde_json::from_str::<HashMap<String, String>>(&content) {
                     for (key, value) in config {
                         let parts: Vec<&str> = key.split(':').collect();
-                        if parts.len() == 2 {
+                        if parts.len() >= 2 {
                             let category = parts[0].to_string();
-                            let name = parts[1].to_string();
+                            let name = parts[1..].join(":");
                             if let Some(widget) = self.config_widgets.get(&category) {
                                 if let Some(option_widget) = widget.options.get(&name) {
                                     self.set_widget_value(option_widget, &value);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -218,9 +218,17 @@ impl ConfigGUI {
                             }
                         }
                     }
-                    self.custom_info_popup("Config Loaded", "HyprGUI configuration loaded successfully.", false);
+                    self.custom_info_popup(
+                        "Config Loaded",
+                        "HyprGUI configuration loaded successfully.",
+                        false,
+                    );
                 } else {
-                    self.custom_error_popup("Invalid Config", "Failed to parse the configuration file.", false);
+                    self.custom_error_popup(
+                        "Invalid Config",
+                        "Failed to parse the configuration file.",
+                        false,
+                    );
                 }
             }
             Err(e) => {
@@ -244,7 +252,11 @@ impl ConfigGUI {
         match serde_json::to_string_pretty(&config) {
             Ok(json) => match fs::write(path, json) {
                 Ok(_) => {
-                    self.custom_info_popup("Config Saved", "HyprGUI configuration saved successfully.", false);
+                    self.custom_info_popup(
+                        "Config Saved",
+                        "HyprGUI configuration saved successfully.",
+                        false,
+                    );
                 }
                 Err(e) => {
                     self.custom_error_popup(

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -125,8 +125,8 @@ impl ConfigGUI {
         popover_box.set_margin_start(5);
         popover_box.set_margin_end(5);
 
-        let load_config_button = Button::with_label("Load HyprGUI Config");
         let save_config_button = Button::with_label("Save HyprGUI Config");
+        let load_config_button = Button::with_label("Load HyprGUI Config");
 
         popover_box.append(&load_config_button);
         popover_box.append(&save_config_button);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
 
 fn build_ui(app: &Application) {
     let gui = Rc::new(RefCell::new(gui::ConfigGUI::new(app)));
+    gui::ConfigGUI::setup_config_buttons(gui.clone());
 
     let config_path_full = get_config_path();
 


### PR DESCRIPTION
1. Adds a gear button to titlebar
2. adds a tooltip to the right of the gear button explaining what the 2 options inside of the gear button do
3. adds a popover that appears when you click the gear button
4. adds 2 buttons inside of the popover "Load HyprGUI Config", "Save HyprGUI Config"
5. adds serde js cate
6. "Save HyprGUI Config" saves the options chosen in the GUI in a json formatted file
7. "Load HyprGUI Config" Loads these save options from the json formatted file and fills them out in the GUI
8. After loading, clicking the save button on the far right is still necessary to then save these imported options.
9. both "Save HyprGUI Config" and "Load HyprGUI Config" open a file picker for the user to choose where they want to save it / load it