### PR TITLE
feat: add a `Copyright` button

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,14 +49,36 @@ fn build_ui(app: &Application) {
         });
 
         let undo_button = Button::with_label("Undo Changes");
+        let copy_button = Button::with_label("Copyright");
+
         let gui_clone = gui.clone();
         undo_button.connect_clicked(move |_| {
             undo_changes(gui_clone.clone());
         });
 
+        let gui_clone = gui.clone();
+        copy_button.connect_clicked(move |_| {
+            gui_clone.borrow_mut().custom_info_popup(
+                "Copyright (C) 2024 Nyx, Adam Perkowski",
+                "This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, version 2 of
+the License.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program; if not, see
+<https://www.gnu.org/licenses/old-licenses/gpl-2.0>.",
+                true,
+            );
+        });
+
         if let Some(gear_menu_box) = gui.borrow().gear_menu.borrow().child() {
             if let Some(box_widget) = gear_menu_box.downcast_ref::<gtk::Box>() {
                 box_widget.append(&undo_button);
+                box_widget.append(&copy_button);
             }
         }
     }


### PR DESCRIPTION
Add a `Copyright` button containing copyright information in the menu at the top right.

See [GPL 2.0 SEC4](https://www.gnu.org/licenses/old-licenses/gpl-2.0#SEC4).
